### PR TITLE
Add ListObjectVersions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ More examples can be found in the examples directory on GitHub.
     * [`DeleteObject`][deleteobject]
     * [`DeleteObjects`][deleteobjects]
     * [`ListObjectsV2`][listobjectsv2]
+    * [`ListObjectVersions`][listobjectversions]
 * Multipart upload
     * [`CreateMultipartUpload`][completemultipart]
     * [`UploadPart`][uploadpart]
@@ -74,6 +75,7 @@ More examples can be found in the examples directory on GitHub.
 [getobject]: https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html
 [headobject]: https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html
 [listobjectsv2]: https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
+[listobjectversions]: https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectVersions.html
 [putobject]: https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
 [uploadpart]: https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ More examples can be found in the examples directory on GitHub.
     * [`CreateBucket`][createbucket]
     * [`DeleteBucket`][deletebucket]
     * [`HeadBucket`][headbucket]
+    * [`PutBucketVersioning`][putbucketversioning]
 * Basic methods
     * [`HeadObject`][headobject]
     * [`GetObject`][getobject]
@@ -76,6 +77,7 @@ More examples can be found in the examples directory on GitHub.
 [headobject]: https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html
 [listobjectsv2]: https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
 [listobjectversions]: https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectVersions.html
+[putbucketversioning]: https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketVersioning.html
 [putobject]: https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
 [uploadpart]: https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart
 

--- a/src/actions/list_object_versions.rs
+++ b/src/actions/list_object_versions.rs
@@ -1,0 +1,287 @@
+use std::borrow::Cow;
+use std::io::{BufReader, Read};
+use std::iter;
+use std::time::Duration;
+
+use jiff::Timestamp;
+use serde::Deserialize;
+use url::Url;
+
+use crate::actions::Method;
+use crate::actions::S3Action;
+use crate::signing::sign;
+use crate::sorting_iter::SortingIterator;
+use crate::{Bucket, Credentials, Map};
+
+/// List all versions of objects in the bucket.
+///
+/// If `next_key_marker` or `next_version_id_marker` is `Some` the response is
+/// truncated, and the rest of the list can be retrieved by reusing the
+/// `ListObjectVersions` action but with `key-marker` and `version-id-marker`
+/// set to the values returned in the previous response.
+///
+/// Find out more about `ListObjectVersions` from the [AWS API Reference][api]
+///
+/// [api]: https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectVersions.html
+#[allow(clippy::module_name_repetitions)]
+#[derive(Debug, Clone)]
+pub struct ListObjectVersions<'a> {
+    bucket: &'a Bucket,
+    credentials: Option<&'a Credentials>,
+
+    query: Map<'a>,
+    headers: Map<'a>,
+}
+
+#[allow(clippy::module_name_repetitions)]
+#[derive(Debug, Clone, Deserialize)]
+pub struct ListObjectVersionsResponse {
+    #[serde(rename = "Version", default)]
+    pub versions: Vec<ObjectVersion>,
+    #[serde(rename = "DeleteMarker", default)]
+    pub delete_markers: Vec<DeleteMarker>,
+    #[serde(rename = "CommonPrefixes", default)]
+    pub common_prefixes: Vec<CommonPrefixes>,
+    #[serde(rename = "MaxKeys")]
+    pub max_keys: Option<u16>,
+    #[serde(rename = "NextKeyMarker")]
+    pub next_key_marker: Option<String>,
+    #[serde(rename = "NextVersionIdMarker")]
+    pub next_version_id_marker: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ObjectVersion {
+    #[serde(rename = "ETag")]
+    pub etag: String,
+    #[serde(rename = "Key")]
+    pub key: String,
+    #[serde(rename = "LastModified")]
+    pub last_modified: String,
+    #[serde(rename = "Owner")]
+    pub owner: Option<ListObjectsOwner>,
+    #[serde(rename = "Size")]
+    pub size: u64,
+    #[serde(rename = "StorageClass")]
+    pub storage_class: Option<String>,
+    #[serde(rename = "VersionId")]
+    pub version_id: String,
+    #[serde(rename = "IsLatest")]
+    pub is_latest: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DeleteMarker {
+    #[serde(rename = "Key")]
+    pub key: String,
+    #[serde(rename = "VersionId")]
+    pub version_id: String,
+    #[serde(rename = "IsLatest")]
+    pub is_latest: bool,
+    #[serde(rename = "LastModified")]
+    pub last_modified: String,
+    #[serde(rename = "Owner")]
+    pub owner: Option<ListObjectsOwner>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ListObjectsOwner {
+    #[serde(rename = "ID")]
+    pub id: String,
+    #[serde(rename = "DisplayName")]
+    pub display_name: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CommonPrefixes {
+    #[serde(rename = "Prefix")]
+    pub prefix: String,
+}
+
+impl<'a> ListObjectVersions<'a> {
+    #[must_use]
+    pub fn new(bucket: &'a Bucket, credentials: Option<&'a Credentials>) -> Self {
+        let mut query = Map::new();
+        query.insert("encoding-type", "url");
+
+        Self {
+            bucket,
+            credentials,
+            query,
+            headers: Map::new(),
+        }
+    }
+
+    /// Limits the response to keys that begin with the specified prefix.
+    pub fn with_prefix(&mut self, prefix: impl Into<Cow<'a, str>>) {
+        self.query_mut().insert("prefix", prefix);
+    }
+
+    /// Sets the maximum number of keys returned in the response.
+    pub fn with_max_keys(&mut self, max_keys: usize) {
+        self.query_mut().insert("max-keys", max_keys.to_string());
+    }
+
+    /// Specify the key to start with when listing.
+    pub fn with_key_marker(&mut self, key: impl Into<Cow<'a, str>>) {
+        self.query_mut().insert("key-marker", key);
+    }
+
+    /// Specify the object version you want to start listing from.
+    pub fn with_version_id_marker(&mut self, version: impl Into<Cow<'a, str>>) {
+        self.query_mut().insert("version-id-marker", version);
+    }
+
+    /// A delimiter is a character that you use to group keys.
+    pub fn with_delimiter(&mut self, delimiter: impl Into<Cow<'a, str>>) {
+        self.query_mut().insert("delimiter", delimiter);
+    }
+
+    /// Parse the XML response from S3 into a struct.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the XML response could not be parsed.
+    pub fn parse_response(
+        s: impl AsRef<[u8]>,
+    ) -> Result<ListObjectVersionsResponse, quick_xml::DeError> {
+        Self::parse_response_from_reader(&mut s.as_ref())
+    }
+
+    /// Parse the XML response from S3 into a struct.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the XML response could not be parsed.
+    pub fn parse_response_from_reader(
+        s: impl Read,
+    ) -> Result<ListObjectVersionsResponse, quick_xml::DeError> {
+        let mut parsed: ListObjectVersionsResponse =
+            quick_xml::de::from_reader(BufReader::new(s))?;
+
+        for version in &mut parsed.versions {
+            if let Some(owner) = &version.owner {
+                if owner.id.is_empty() && owner.display_name.is_empty() {
+                    version.owner = None;
+                }
+            }
+        }
+        for marker in &mut parsed.delete_markers {
+            if let Some(owner) = &marker.owner {
+                if owner.id.is_empty() && owner.display_name.is_empty() {
+                    marker.owner = None;
+                }
+            }
+        }
+
+        Ok(parsed)
+    }
+}
+
+impl<'a> S3Action<'a> for ListObjectVersions<'a> {
+    const METHOD: Method = Method::Get;
+
+    fn query_mut(&mut self) -> &mut Map<'a> {
+        &mut self.query
+    }
+
+    fn headers_mut(&mut self) -> &mut Map<'a> {
+        &mut self.headers
+    }
+
+    fn sign_with_time(&self, expires_in: Duration, time: &Timestamp) -> Url {
+        let url = self.bucket.base_url().clone();
+        let query = SortingIterator::new(iter::once(("versions", "1")), self.query.iter());
+
+        match self.credentials {
+            Some(credentials) => sign(
+                time,
+                Self::METHOD,
+                url,
+                credentials.key(),
+                credentials.secret(),
+                credentials.token(),
+                self.bucket.region(),
+                expires_in.as_secs(),
+                query,
+                self.headers.iter(),
+            ),
+            None => crate::signing::util::add_query_params(url, query),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+    use crate::{Bucket, UrlStyle};
+
+    #[test]
+    fn anonymous_custom_query() {
+        let expires_in = Duration::from_secs(86400);
+
+        let endpoint = "https://s3.amazonaws.com".parse().unwrap();
+        let bucket = Bucket::new(
+            endpoint,
+            UrlStyle::VirtualHost,
+            "examplebucket",
+            "us-east-1",
+        )
+        .unwrap();
+
+        let mut action = ListObjectVersions::new(&bucket, None);
+        action.with_prefix("duck");
+        let url = action.sign(expires_in);
+        let expected = "https://examplebucket.s3.amazonaws.com/?encoding-type=url&prefix=duck&versions=1";
+        assert_eq!(expected, url.as_str());
+    }
+
+    #[test]
+    fn parse() {
+        let input = r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <ListVersionsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+            <Name>bucket</Name>
+            <Prefix>my</Prefix>
+            <KeyMarker></KeyMarker>
+            <VersionIdMarker></VersionIdMarker>
+            <MaxKeys>5</MaxKeys>
+            <IsTruncated>false</IsTruncated>
+            <Version>
+                <Key>my-image.jpg</Key>
+                <VersionId>3/L4kqtJl40Nr8X8gdRQBpUMLUo</VersionId>
+                <IsLatest>true</IsLatest>
+                <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+                <ETag>"fba9dede5f27731c9771645a39863328"</ETag>
+                <Size>434234</Size>
+                <Owner>
+                    <ID></ID>
+                    <DisplayName></DisplayName>
+                </Owner>
+                <StorageClass>STANDARD</StorageClass>
+            </Version>
+            <DeleteMarker>
+                <Key>old-file.jpg</Key>
+                <VersionId>abc123</VersionId>
+                <IsLatest>false</IsLatest>
+                <LastModified>2009-10-11T17:50:30.000Z</LastModified>
+                <Owner>
+                    <ID></ID>
+                    <DisplayName></DisplayName>
+                </Owner>
+            </DeleteMarker>
+            <EncodingType>url</EncodingType>
+        </ListVersionsResult>
+        "#;
+
+        let parsed = ListObjectVersions::parse_response(input).unwrap();
+        assert_eq!(parsed.versions.len(), 1);
+        assert_eq!(parsed.delete_markers.len(), 1);
+        let v = &parsed.versions[0];
+        assert_eq!(v.key, "my-image.jpg");
+        assert_eq!(v.version_id, "3/L4kqtJl40Nr8X8gdRQBpUMLUo");
+        assert!(v.owner.is_none());
+    }
+}

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -17,10 +17,10 @@ pub use self::head_bucket::HeadBucket;
 pub use self::head_object::HeadObject;
 #[cfg(feature = "full")]
 #[doc(inline)]
-pub use self::list_objects_v2::{ListObjectsV2, ListObjectsV2Response};
+pub use self::list_object_versions::{ListObjectVersions, ListObjectVersionsResponse};
 #[cfg(feature = "full")]
 #[doc(inline)]
-pub use self::list_object_versions::{ListObjectVersions, ListObjectVersionsResponse};
+pub use self::list_objects_v2::{ListObjectsV2, ListObjectsV2Response};
 pub use self::multipart_upload::abort::AbortMultipartUpload;
 #[cfg(feature = "full")]
 pub use self::multipart_upload::complete::CompleteMultipartUpload;
@@ -29,6 +29,8 @@ pub use self::multipart_upload::create::{CreateMultipartUpload, CreateMultipartU
 #[cfg(feature = "full")]
 pub use self::multipart_upload::list_parts::{ListParts, ListPartsResponse};
 pub use self::multipart_upload::upload::UploadPart;
+#[cfg(feature = "full")]
+pub use self::put_bucket_versioning::{PutBucketVersioning, VersioningStatus};
 pub use self::put_object::PutObject;
 use crate::{Map, Method};
 
@@ -43,10 +45,12 @@ mod get_object;
 mod head_bucket;
 mod head_object;
 #[cfg(feature = "full")]
-pub mod list_objects_v2;
-#[cfg(feature = "full")]
 pub mod list_object_versions;
+#[cfg(feature = "full")]
+pub mod list_objects_v2;
 mod multipart_upload;
+#[cfg(feature = "full")]
+mod put_bucket_versioning;
 mod put_object;
 
 /// A request which can be signed

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -18,6 +18,9 @@ pub use self::head_object::HeadObject;
 #[cfg(feature = "full")]
 #[doc(inline)]
 pub use self::list_objects_v2::{ListObjectsV2, ListObjectsV2Response};
+#[cfg(feature = "full")]
+#[doc(inline)]
+pub use self::list_object_versions::{ListObjectVersions, ListObjectVersionsResponse};
 pub use self::multipart_upload::abort::AbortMultipartUpload;
 #[cfg(feature = "full")]
 pub use self::multipart_upload::complete::CompleteMultipartUpload;
@@ -41,6 +44,8 @@ mod head_bucket;
 mod head_object;
 #[cfg(feature = "full")]
 pub mod list_objects_v2;
+#[cfg(feature = "full")]
+pub mod list_object_versions;
 mod multipart_upload;
 mod put_object;
 

--- a/src/actions/put_bucket_versioning.rs
+++ b/src/actions/put_bucket_versioning.rs
@@ -1,0 +1,150 @@
+use std::iter;
+use std::time::Duration;
+
+use jiff::Timestamp;
+use url::Url;
+
+use crate::actions::Method;
+use crate::actions::S3Action;
+use crate::signing::sign;
+use crate::sorting_iter::SortingIterator;
+use crate::{Bucket, Credentials, Map};
+
+/// Versioning status for a bucket.
+#[allow(clippy::module_name_repetitions)]
+#[derive(Debug, Clone, Copy)]
+pub enum VersioningStatus {
+    Enabled,
+    Suspended,
+}
+
+impl VersioningStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Enabled => "Enabled",
+            Self::Suspended => "Suspended",
+        }
+    }
+}
+
+/// Configure bucket versioning.
+///
+/// Find out more about `PutBucketVersioning` from the [AWS API Reference][api]
+///
+/// [api]: https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketVersioning.html
+#[allow(clippy::module_name_repetitions)]
+#[derive(Debug, Clone)]
+pub struct PutBucketVersioning<'a> {
+    bucket: &'a Bucket,
+    credentials: &'a Credentials,
+    status: VersioningStatus,
+    mfa_delete: Option<bool>,
+
+    query: Map<'a>,
+    headers: Map<'a>,
+}
+
+impl<'a> PutBucketVersioning<'a> {
+    #[must_use]
+    pub const fn new(
+        bucket: &'a Bucket,
+        credentials: &'a Credentials,
+        status: VersioningStatus,
+    ) -> Self {
+        Self {
+            bucket,
+            credentials,
+            status,
+            mfa_delete: None,
+            query: Map::new(),
+            headers: Map::new(),
+        }
+    }
+
+    /// Sets MFA delete for the bucket configuration.
+    pub fn set_mfa_delete(&mut self, enabled: bool) {
+        self.mfa_delete = Some(enabled);
+    }
+
+    /// Generate the XML body for the request.
+    #[must_use]
+    pub fn body(&self) -> String {
+        let mut body = String::from(
+            "<VersioningConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">",
+        );
+        body.push_str("<Status>");
+        body.push_str(self.status.as_str());
+        body.push_str("</Status>");
+        if let Some(enabled) = self.mfa_delete {
+            body.push_str("<MfaDelete>");
+            body.push_str(if enabled { "Enabled" } else { "Disabled" });
+            body.push_str("</MfaDelete>");
+        }
+        body.push_str("</VersioningConfiguration>");
+        body
+    }
+}
+
+impl<'a> S3Action<'a> for PutBucketVersioning<'a> {
+    const METHOD: Method = Method::Put;
+
+    fn query_mut(&mut self) -> &mut Map<'a> {
+        &mut self.query
+    }
+
+    fn headers_mut(&mut self) -> &mut Map<'a> {
+        &mut self.headers
+    }
+
+    fn sign_with_time(&self, expires_in: Duration, time: &Timestamp) -> Url {
+        let url = self.bucket.base_url().clone();
+        let query = SortingIterator::new(iter::once(("versioning", "")), self.query.iter());
+
+        sign(
+            time,
+            Self::METHOD,
+            url,
+            self.credentials.key(),
+            self.credentials.secret(),
+            self.credentials.token(),
+            self.bucket.region(),
+            expires_in.as_secs(),
+            query,
+            self.headers.iter(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+    use crate::{Bucket, Credentials, UrlStyle};
+
+    #[test]
+    fn aws_example() {
+        // Fri, 24 May 2013 00:00:00 GMT
+        let date = Timestamp::from_second(1369353600).unwrap();
+        let expires_in = Duration::from_secs(86400);
+
+        let endpoint = "https://s3.amazonaws.com".parse().unwrap();
+        let bucket = Bucket::new(
+            endpoint,
+            UrlStyle::VirtualHost,
+            "examplebucket",
+            "us-east-1",
+        )
+        .unwrap();
+        let credentials = Credentials::new(
+            "AKIAIOSFODNN7EXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        );
+
+        let action = PutBucketVersioning::new(&bucket, &credentials, VersioningStatus::Enabled);
+
+        let url = action.sign_with_time(expires_in, &date);
+        let expected = "https://examplebucket.s3.amazonaws.com/?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20130524T000000Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&versioning=&X-Amz-Signature=5507edf05c88e5851c42c3e376155fcad696114350881b32606e76caabefd13f";
+        assert_eq!(expected, url.as_str());
+    }
+}

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -11,6 +11,7 @@ use crate::actions::{
 #[cfg(feature = "full")]
 use crate::actions::{
     CompleteMultipartUpload, CreateMultipartUpload, DeleteObjects, ListObjectsV2, ListParts,
+    ListObjectVersions,
 };
 use crate::signing::util::percent_encode_path;
 use crate::Credentials;
@@ -226,6 +227,18 @@ impl Bucket {
         credentials: Option<&'a Credentials>,
     ) -> ListObjectsV2<'a> {
         ListObjectsV2::new(self, credentials)
+    }
+
+    /// List all versions of the objects in the bucket.
+    ///
+    /// See [`ListObjectVersions`] for more details.
+    #[cfg(feature = "full")]
+    #[must_use]
+    pub fn list_object_versions<'a>(
+        &'a self,
+        credentials: Option<&'a Credentials>,
+    ) -> ListObjectVersions<'a> {
+        ListObjectVersions::new(self, credentials)
     }
 
     /// Upload a file to S3, using a `PUT` request.

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -10,8 +10,8 @@ use crate::actions::{
 };
 #[cfg(feature = "full")]
 use crate::actions::{
-    CompleteMultipartUpload, CreateMultipartUpload, DeleteObjects, ListObjectsV2, ListParts,
-    ListObjectVersions,
+    CompleteMultipartUpload, CreateMultipartUpload, DeleteObjects, ListObjectVersions,
+    ListObjectsV2, ListParts, PutBucketVersioning, VersioningStatus,
 };
 use crate::signing::util::percent_encode_path;
 use crate::Credentials;
@@ -239,6 +239,19 @@ impl Bucket {
         credentials: Option<&'a Credentials>,
     ) -> ListObjectVersions<'a> {
         ListObjectVersions::new(self, credentials)
+    }
+
+    /// Change the versioning status of this bucket.
+    ///
+    /// See [`PutBucketVersioning`] for more details.
+    #[cfg(feature = "full")]
+    #[must_use]
+    pub const fn put_bucket_versioning<'a>(
+        &'a self,
+        credentials: &'a Credentials,
+        status: VersioningStatus,
+    ) -> PutBucketVersioning<'a> {
+        PutBucketVersioning::new(self, credentials, status)
     }
 
     /// Upload a file to S3, using a `PUT` request.

--- a/tests/list_object_versions.rs
+++ b/tests/list_object_versions.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use rusty_s3::actions::{ListObjectVersions, S3Action as _};
+use rusty_s3::actions::{VersioningStatus};
 
 mod common;
 
@@ -25,5 +26,59 @@ async fn list_object_versions_empty() {
         ListObjectVersions::parse_response(&text).expect("ListObjectVersions parse response");
 
     assert!(versions.versions.is_empty());
+    assert!(versions.delete_markers.is_empty());
+}
+
+#[tokio::test]
+async fn list_object_versions_multiple() {
+    let (bucket, credentials, client) = common::bucket().await;
+
+    // Enable versioning for the bucket
+    let action = bucket.put_bucket_versioning(&credentials, VersioningStatus::Enabled);
+    let url = action.sign(Duration::from_secs(60));
+    let body = action.body();
+    client
+        .put(url)
+        .body(body)
+        .send()
+        .await
+        .expect("send PutBucketVersioning")
+        .error_for_status()
+        .expect("PutBucketVersioning unexpected status code");
+
+    // Upload multiple versions of the same key
+    let key = "multi.txt";
+    for data in ["first", "second", "third"] {
+        let action = bucket.put_object(Some(&credentials), key);
+        let url = action.sign(Duration::from_secs(60));
+        client
+            .put(url)
+            .body(data.as_bytes().to_vec())
+            .send()
+            .await
+            .expect("send PutObject")
+            .error_for_status()
+            .expect("PutObject unexpected status code");
+    }
+
+    // List object versions
+    let action = bucket.list_object_versions(Some(&credentials));
+    let url = action.sign(Duration::from_secs(60));
+    let resp = client
+        .get(url)
+        .send()
+        .await
+        .expect("send ListObjectVersions")
+        .error_for_status()
+        .expect("ListObjectVersions unexpected status code");
+    let text = resp
+        .text()
+        .await
+        .expect("ListObjectVersions read response body");
+    let versions =
+        ListObjectVersions::parse_response(&text).expect("ListObjectVersions parse response");
+
+    let count = versions.versions.iter().filter(|v| v.key == key).count();
+    assert_eq!(count, 3);
     assert!(versions.delete_markers.is_empty());
 }

--- a/tests/list_object_versions.rs
+++ b/tests/list_object_versions.rs
@@ -1,0 +1,29 @@
+use std::time::Duration;
+
+use rusty_s3::actions::{ListObjectVersions, S3Action as _};
+
+mod common;
+
+#[tokio::test]
+async fn list_object_versions_empty() {
+    let (bucket, credentials, client) = common::bucket().await;
+
+    let action = bucket.list_object_versions(Some(&credentials));
+    let url = action.sign(Duration::from_secs(60));
+    let resp = client
+        .get(url)
+        .send()
+        .await
+        .expect("send ListObjectVersions")
+        .error_for_status()
+        .expect("ListObjectVersions unexpected status code");
+    let text = resp
+        .text()
+        .await
+        .expect("ListObjectVersions read response body");
+    let versions =
+        ListObjectVersions::parse_response(&text).expect("ListObjectVersions parse response");
+
+    assert!(versions.versions.is_empty());
+    assert!(versions.delete_markers.is_empty());
+}

--- a/tests/put_bucket_versioning.rs
+++ b/tests/put_bucket_versioning.rs
@@ -1,0 +1,22 @@
+use std::time::Duration;
+
+use rusty_s3::actions::{PutBucketVersioning, S3Action as _, VersioningStatus};
+
+mod common;
+
+#[tokio::test]
+async fn enable_versioning() {
+    let (bucket, credentials, client) = common::bucket().await;
+
+    let action = bucket.put_bucket_versioning(&credentials, VersioningStatus::Enabled);
+    let url = action.sign(Duration::from_secs(60));
+    let body = action.body();
+    client
+        .put(url)
+        .body(body)
+        .send()
+        .await
+        .expect("send PutBucketVersioning")
+        .error_for_status()
+        .expect("PutBucketVersioning unexpected status code");
+}


### PR DESCRIPTION
## Summary
- support listing object versions via new `ListObjectVersions` action
- expose `list_object_versions` on `Bucket`
- test parsing and signing

## Testing
- `cargo test --lib --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6879e4a27ee48321af208cec92b54f3e